### PR TITLE
feat: allow to deploy flower

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,15 @@ CELERY_CMS_EXPLICIT_QUEUES:
     queue: edx.cms.core.high
 ```
 
+### Enable flower
+
+For troubleshooting purposes, you can enable a flower deployment to monitor in realtime the Celery queues
+times and performance:
+
+```yaml
+CELERY_FLOWER: true
+```
+
 License
 *******
 

--- a/tutorcelery/patches/k8s-deployments
+++ b/tutorcelery/patches/k8s-deployments
@@ -80,4 +80,6 @@ spec:
             value: redis://{{ REDIS_USERNAME }}:{{ REDIS_PASSWORD }}@{{ REDIS_HOST }}:{{ REDIS_PORT }}/{{ OPENEDX_CELERY_REDIS_DB }}
           - name: FLOWER_PORT
             value: "5555"
+          - name: FLOWER_BASIC_AUTH
+            value: {{CELERY_FLOWER_BASIC_AUTH}}
 {%- endif %}

--- a/tutorcelery/patches/k8s-deployments
+++ b/tutorcelery/patches/k8s-deployments
@@ -54,6 +54,7 @@ spec:
 {% endfor %}
 
 {% if CELERY_FLOWER -%}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/tutorcelery/patches/k8s-deployments
+++ b/tutorcelery/patches/k8s-deployments
@@ -52,3 +52,31 @@ spec:
             name: openedx-config
 {% endfor %}
 {% endfor %}
+
+{% if CELERY_FLOWER -%}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: flower
+  labels:
+    app.kubernetes.io/name: flower
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: flower
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: flower
+    spec:
+      containers:
+        - name: flower-edxapp
+          image: docker.io/mher/flower:0.9.5
+          ports:
+            - containerPort: 5555
+          env:
+          - name: CELERY_BROKER_URL
+            value: redis://{{ REDIS_USERNAME }}:{{ REDIS_PASSWORD }}@{{ REDIS_HOST }}:{{ REDIS_PORT }}/{{ OPENEDX_CELERY_REDIS_DB }}
+          - name: FLOWER_PORT
+            value: "5555"
+{%- endif %}

--- a/tutorcelery/patches/k8s-deployments
+++ b/tutorcelery/patches/k8s-deployments
@@ -70,8 +70,8 @@ spec:
         app.kubernetes.io/name: flower
     spec:
       containers:
-        - name: flower-edxapp
-          image: docker.io/mher/flower:0.9.5
+        - name: flower
+          image: {{CELERY_FLOWER_DOCKER_IMAGE}}
           ports:
             - containerPort: 5555
           env:

--- a/tutorcelery/patches/openedx-cms-production-settings
+++ b/tutorcelery/patches/openedx-cms-production-settings
@@ -2,3 +2,6 @@ try:
     EXPLICIT_QUEUES.update({{CELERY_CMS_EXPLICIT_QUEUES}})
 except NameError:
     EXPLICIT_QUEUES = {{CELERY_CMS_EXPLICIT_QUEUES}}
+
+# Prevents losing tasks when workers are shutdown
+CELERY_ACKS_LATE = True

--- a/tutorcelery/patches/openedx-lms-production-settings
+++ b/tutorcelery/patches/openedx-lms-production-settings
@@ -2,3 +2,6 @@ try:
     EXPLICIT_QUEUES.update({{CELERY_LMS_EXPLICIT_QUEUES}})
 except NameError:
     EXPLICIT_QUEUES = {{CELERY_LMS_EXPLICIT_QUEUES}}
+
+# Prevents losing tasks when workers are shutdown
+CELERY_ACKS_LATE = True

--- a/tutorcelery/plugin.py
+++ b/tutorcelery/plugin.py
@@ -25,6 +25,7 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
         ),
         ("CELERY_LMS_EXPLICIT_QUEUES", {}),
         ("CELERY_CMS_EXPLICIT_QUEUES", {}),
+        ("CELERY_FLOWER", False),
     ]
 )
 

--- a/tutorcelery/plugin.py
+++ b/tutorcelery/plugin.py
@@ -26,6 +26,8 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
         ("CELERY_LMS_EXPLICIT_QUEUES", {}),
         ("CELERY_CMS_EXPLICIT_QUEUES", {}),
         ("CELERY_FLOWER", False),
+        ("CELERY_FLOWER_HOST", "flower.{{LMS_HOST}}"),
+        ("CELERY_FLOWER_DOCKER_IMAGE", "docker.io/mher/flower:2.0.1"),
     ]
 )
 

--- a/tutorcelery/plugin.py
+++ b/tutorcelery/plugin.py
@@ -39,6 +39,7 @@ hooks.Filters.CONFIG_UNIQUE.add_items(
         # Prefix your setting names with 'CELERY_'.
         # For example:
         ### ("CELERY_SECRET_KEY", "{{ 24|random_string }}"),
+        ("CELERY_FLOWER_BASIC_AUTH", "flower:{{ 24 |random_string }}")
     ]
 )
 


### PR DESCRIPTION
### Description

This PR allows the deployment of Flower in k8s. It also enables `CELERY_ACK_LATE` to prevent stopped tasks to be marked as completed. The flower image uses the latest one.

![image](https://github.com/user-attachments/assets/3156af3e-bb88-40be-8295-19cbc92e71d5)
