### PR TITLE
fix: remove unnecessary schema property for service monitor

### DIFF
--- a/resources/configmap.yaml
+++ b/resources/configmap.yaml
@@ -26,7 +26,7 @@ data:
           }
         ]
       },
-      "description": "Basic celery monitoring example",
+      "description": "Basic celery monitoring.",
       "editable": true,
       "fiscalYearStartMonth": 0,
       "graphTooltip": 0,
@@ -946,7 +946,7 @@ data:
       },
       "timepicker": {},
       "timezone": "",
-      "title": "Celery Monitoring Copy",
+      "title": "Celery Monitoring",
       "uid": "edvf7swydsutcc",
       "version": 1,
       "weekStart": ""

--- a/resources/configmap.yaml
+++ b/resources/configmap.yaml
@@ -889,7 +889,7 @@ data:
           "type": "timeseries"
         }
       ],
-      "refresh": "5s",
+      "refresh": "5m",
       "schemaVersion": 39,
       "tags": [],
       "templating": {

--- a/tutorcelery/patches/k8s-deployments
+++ b/tutorcelery/patches/k8s-deployments
@@ -100,7 +100,6 @@ spec:
     port: metrics
     honorLabels: true
     path: /metrics
-    schema: http
   namespaceSelector:
     matchNames:
     - {{ K8S_NAMESPACE }}


### PR DESCRIPTION
### Description

Removing the `schema` property as their default value is already `http` and the property name is `scheme`.