### PR TITLE
feat: add gevent as an openedx requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,10 +216,7 @@ def _add_celery_workers_config(workers_config):
         "min_replicas": 0,
         "max_replicas": 10,
         "enable_keda": False,
-        "extra_params": [
-          "--pool=gevent",
-          "--concurrency=100",
-        ]
+        "extra_params": []
     }
 
     return workers_config

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "tutor>=18.2,<19.0.0"
 ]
 
-optional-dependencies = { dev = ["python-semantic-release", "pylint", "black"]}
+optional-dependencies = { dev = ["python-semantic-release", "pylint", "black", "build"]}
 
 [project.urls]
 Homepage = "https://github.com/edunext/tutor-contrib-celery"

--- a/tutorcelery/patches/k8s-deployments
+++ b/tutorcelery/patches/k8s-deployments
@@ -30,6 +30,9 @@ spec:
             - "--loglevel=info"
             - "--hostname=edx.{{service}}.core.{{variant}}.%%h"
             - "--max-tasks-per-child=100"
+            - "--prefetch-multiplier=1"
+            - "--without-gossip"
+            - "--without-mingle"
             - "--queues=edx.{{service}}.core.{{variant}}"
             {% for param in config.get("extra_params", []) %}
             - "{{param}}"

--- a/tutorcelery/patches/openedx-dockerfile-post-python-requirements
+++ b/tutorcelery/patches/openedx-dockerfile-post-python-requirements
@@ -1,0 +1,2 @@
+RUN --mount=type=cache,target=/openedx/.cache/pip,sharing=shared \
+    pip install "gevent==24.11.1"


### PR DESCRIPTION
This PR adds `gevent` as an openedx requirement, allowing celery workers to run with a pool optimized for I/O bound tasks.

It also adds an examples for the recommended settings on a production system and for running a specific (and optimized) celery queue for Aspects.