### PR TITLE
build: add the build package to dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,11 +29,12 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-  "python-semantic-release",
+  "build",
   "black",
+  "isort",
   "mypy",
   "pylint",
-  "isort",
+  "python-semantic-release",
 ]
 
 [project.urls]


### PR DESCRIPTION
This is used to build the wheel needed to publish in PyPI