### PR TITLE
build: add build dependency needed for the publish workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,10 @@ local-release:
 	@echo "You can push the changes and release manually."
 	semantic-release version --changelog --commit --no-push
 
+dryrun-release:
+	@echo "New release dryrun"
+	semantic-release --noop version  --changelog --commit --push --tag
+
 ESCAPE = 
 help: ## Print this help
 	@grep -E '^([a-zA-Z_-]+:.*?## .*|######* .+)$$' Makefile \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,11 +29,12 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-  "python-semantic-release",
+  "build",
   "black",
+  "isort",
   "mypy",
   "pylint",
-  "isort",
+  "python-semantic-release",
 ]
 
 [project.urls]


### PR DESCRIPTION
The release workflow failed while building the wheel.

Also include a make target to test the new release.